### PR TITLE
PFM.API: Add Serilog support

### DIFF
--- a/PFM.Api/src/PFM.Api/Controllers/AccountController.cs
+++ b/PFM.Api/src/PFM.Api/Controllers/AccountController.cs
@@ -6,6 +6,11 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Authorization;
 using PFM.Api.Configuration;
 using PFM.Api.Contracts.UserAccount;
+using Microsoft.Extensions.Logging;
+using SerilogTimings;
+using Serilog.Context;
+using System;
+using Microsoft.AspNetCore.Http;
 
 namespace PFM.Api.Controllers
 {
@@ -16,51 +21,80 @@ namespace PFM.Api.Controllers
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IConfiguration _configuration;
+        private readonly Serilog.ILogger _logger;
 
-        public AccountController(UserManager<IdentityUser> userManager, SignInManager<IdentityUser> signInManager, IConfiguration configuration)
+        public AccountController(UserManager<IdentityUser> userManager, SignInManager<IdentityUser> signInManager, IConfiguration configuration, Serilog.ILogger logger)
         {
             _userManager = userManager;
             _signInManager = signInManager;
             _configuration = configuration;
+            _logger = logger;
         }
 
         [AllowAnonymous]
         [HttpPost("Login")]
-        public async Task<AuthenticatedUser> Login([FromBody]User model)
+        public async Task<object> Login([FromBody]User model)
         {
-            var result = await _signInManager.PasswordSignInAsync(model.Email, model.Password, false, false);
-
-            if (result.Succeeded)
+            using (Operation.Time("User login"))
+            using (LogContext.PushProperty("UserName", model.Email))
             {
-                var appUser = _userManager.Users.SingleOrDefault(r => r.Email == model.Email);
-                var token = TokenFactory.GenerateJwtToken(model.Email, appUser, _configuration);
-                return new AuthenticatedUser() {
-                    Token = token,
-                    UserId = appUser.Id
-                };
-            }
+                try
+                {
+                    var result = await _signInManager.PasswordSignInAsync(model.Email, model.Password, false, false);
 
-            return null;
+                    if (result.Succeeded)
+                    {
+                        var appUser = _userManager.Users.SingleOrDefault(r => r.Email == model.Email);
+                        var token = TokenFactory.GenerateJwtToken(model.Email, appUser, _configuration);
+                        return new AuthenticatedUser()
+                        {
+                            Token = token,
+                            UserId = appUser.Id
+                        };
+                    }
+
+                    _logger.Warning("User authentication failed");
+                    return BadRequest("Authentication Failed.");
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error(ex, "Unhandled Exception");
+                    return new StatusCodeResult(StatusCodes.Status500InternalServerError);
+                }
+            }
         }
 
         [AllowAnonymous]
         [HttpPost("Register")]
         public async Task<object> Register([FromBody]User model)
         {
-            var user = new IdentityUser
+            try
             {
-                UserName = model.Email,
-                Email = model.Email
-            };
-            var result = await _userManager.CreateAsync(user, model.Password);
+                using (Operation.Time("User registration"))
+                using (LogContext.PushProperty("UserName", model.Email))
+                {
+                    var user = new IdentityUser
+                    {
+                        UserName = model.Email,
+                        Email = model.Email
+                    };
+                    var result = await _userManager.CreateAsync(user, model.Password);
 
-            if (result.Succeeded)
-            {
-                await _signInManager.SignInAsync(user, false);
-                return TokenFactory.GenerateJwtToken(model.Email, user, _configuration);
+                    if (result.Succeeded)
+                    {
+                        await _signInManager.SignInAsync(user, false);
+                        return TokenFactory.GenerateJwtToken(model.Email, user, _configuration);
+                    }
+
+                    _logger.Warning("User registration failed");
+                    return BadRequest(result.Errors);
+                }
             }
-
-            return null;
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unhandled Exception");
+                return new StatusCodeResult(StatusCodes.Status500InternalServerError);
+            }
         }
     }
 }

--- a/PFM.Api/src/PFM.Api/Middlewares/TimedOperationMiddleware.cs
+++ b/PFM.Api/src/PFM.Api/Middlewares/TimedOperationMiddleware.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace PFM.Api.Middlewares
+{
+    public class UnhandledExceptionMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly Serilog.ILogger _logger;
+
+        public UnhandledExceptionMiddleware(RequestDelegate next, Serilog.ILogger logger)
+        {
+            _logger = logger;
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext httpContext)
+        {
+            try
+            {
+                await _next(httpContext);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unhandled exception occurred");
+                await HandleExceptionAsync(httpContext);
+            }
+        }
+
+        private async Task HandleExceptionAsync(HttpContext context)
+        {
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            await context.Response.WriteAsync($"Go check the application logs!");
+        }
+    }
+}

--- a/PFM.Api/src/PFM.Api/Middlewares/UnhandledExceptionMiddleware.cs
+++ b/PFM.Api/src/PFM.Api/Middlewares/UnhandledExceptionMiddleware.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Http;
+using SerilogTimings;
+using System.Threading.Tasks;
+
+namespace PFM.Api.Middlewares
+{
+    public class TimedOperationMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public TimedOperationMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext httpContext)
+        {
+            using (var op = Operation.Begin($"{httpContext.Request.Method} {httpContext.Request.Path}"))
+            {
+                await _next(httpContext);
+                op.Complete();
+            }
+        }
+    }
+}

--- a/PFM.Api/src/PFM.Api/PFM.Api.csproj
+++ b/PFM.Api/src/PFM.Api/PFM.Api.csproj
@@ -18,6 +18,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="2.1.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.2.4" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.3" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.1" />
+    <PackageReference Include="SerilogTimings" Version="3.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="3.0.0" />

--- a/PFM.Api/src/PFM.Api/Startup.cs
+++ b/PFM.Api/src/PFM.Api/Startup.cs
@@ -1,27 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Autofac;
+﻿using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using AutoMapper;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using PFM.DataAccessLayer;
-using Swashbuckle.AspNetCore.Swagger;
-using PFM.Services.Core.Automapper;
-using Microsoft.AspNetCore.Identity;
-using System.IdentityModel.Tokens.Jwt;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using PFM.DataAccessLayer;
+using PFM.Services.Core.Automapper;
+using Serilog;
+using Swashbuckle.AspNetCore.Swagger;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Text;
-using Microsoft.AspNetCore.Mvc.Authorization;
-using Microsoft.AspNetCore.Authorization;
 
 namespace PFM.Api
 {
@@ -30,6 +28,10 @@ namespace PFM.Api
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
+
+            Log.Logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .CreateLogger();
         }
 
         public IConfiguration Configuration { get; }
@@ -37,6 +39,8 @@ namespace PFM.Api
         // This method gets called by the runtime. Use this method to add services to the container.
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton(Log.Logger);
+
             services.AddMvc(o => {
                 var policy = new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme).RequireAuthenticatedUser().Build();
                 o.Filters.Add(new AuthorizeFilter(policy));

--- a/PFM.Api/src/PFM.Api/Startup.cs
+++ b/PFM.Api/src/PFM.Api/Startup.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using PFM.DataAccessLayer;
 using PFM.Services.Core.Automapper;
@@ -31,6 +30,7 @@ namespace PFM.Api
 
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
+                .Enrich.FromLogContext()
                 .CreateLogger();
         }
 

--- a/PFM.Api/src/PFM.Api/Startup.cs
+++ b/PFM.Api/src/PFM.Api/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
+using PFM.Api.Middlewares;
 using PFM.DataAccessLayer;
 using PFM.Services.Core.Automapper;
 using Serilog;
@@ -104,6 +105,9 @@ namespace PFM.Api
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            app.UseMiddleware<TimedOperationMiddleware>();
+            app.UseMiddleware<UnhandledExceptionMiddleware>();
 
             app.UseSwagger();
             app.UseSwaggerUI(c =>

--- a/PFM.Api/src/PFM.Api/appsettings.Development.json
+++ b/PFM.Api/src/PFM.Api/appsettings.Development.json
@@ -1,12 +1,4 @@
 ﻿{
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
-  },
   "ConnectionStrings": {
     "PFMConnection": "Server=localhost,1433;Database=PFM_MAIN_DB;User Id=PFM_API_SVC;Password=Helloworld123!"
   }

--- a/PFM.Api/src/PFM.Api/appsettings.json
+++ b/PFM.Api/src/PFM.Api/appsettings.json
@@ -1,15 +1,19 @@
 ﻿{
-  "Logging": {
-    "IncludeScopes": false,
-    "Debug": {
-      "LogLevel": {
-        "Default": "Warning"
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.Seq"
+    ],
+    "MinimumLevel": "Debug",
+    "WriteTo": [
+      { "Name": "Console" },
+      {
+        "Name": "Seq",
+        "Args": { "serverUrl": "http://localhost:5341" }
       }
-    },
-    "Console": {
-      "LogLevel": {
-        "Default": "Warning"
-      }
+    ],
+    "Properties": {
+      "Application": "PFM.Api"
     }
   },
   "ConnectionStrings": {

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ The plan is to consolidate the existing setup to reduce the risk of regressions;
 - [x] Add CI Support (GitHub Action)
 - [x] Simplify local setup/development using SQL Server (Docker)
 - [x] Build & Publish API.Contracts (GitHub Packages)
-- [ ] Support SEQ Logging in PFM.Api
-- [ ] PFM.Auth.API Auth DB setup
+- [x] Support SEQ Logging in PFM.Api
 - [ ] PFM.Auth.API code import in the PFM repository
+- [ ] PFM.Auth.API Auth DB setup
+- [ ] Support SEQ Logging in PFM.Auth.API
 - [ ] PFM.API forwarding Login/Register requests to the PFM.Auth.Api
 
 ## Getting Started


### PR DESCRIPTION
## Changelog

### Global
- N/A

### PFM API
- Add Serilog support.
- Add two middlewares: one for exception handling and one for logging requests.
- Add a log and bad request response when the calls for auth actions are unsuccessful. 

### PFM Website
- N/A

## Comments
- N/A