### PR TITLE
PFM Auth API: SHA256Managed is obsolete

### DIFF
--- a/PFM.Auth.Api/src/PFM.Authentication.Api/Services/UserService.cs
+++ b/PFM.Auth.Api/src/PFM.Authentication.Api/Services/UserService.cs
@@ -110,21 +110,10 @@ namespace PFM.Authentication.Api.Services
             var plainText = Encoding.ASCII.GetBytes(password);
             var salt = Encoding.ASCII.GetBytes(saltStr);
 
-            HashAlgorithm algorithm = new SHA256Managed();
-
-            byte[] plainTextWithSaltBytes =
-              new byte[plainText.Length + salt.Length];
-
-            for (int i = 0; i < plainText.Length; i++)
+            using (var alg = SHA512.Create())
             {
-                plainTextWithSaltBytes[i] = plainText[i];
+                return alg.ComputeHash(new byte[plainText.Length + salt.Length]);
             }
-            for (int i = 0; i < salt.Length; i++)
-            {
-                plainTextWithSaltBytes[plainText.Length + i] = salt[i];
-            }
-
-            return algorithm.ComputeHash(plainTextWithSaltBytes);
         }
 
         public Task<UserResponse> GetAuthenticatedUser(ClaimsIdentity identity)


### PR DESCRIPTION
## Changelog

### Global
- N/A

### PFM API
- N/A

### PFM Auth API
- Replace SHA256Managed which is obsolete

### PFM Website
- N/A

## Comments
- N/A