### PR TITLE
Add support for SEQ in PFM.Website & Fix contracts

### DIFF
--- a/.github/workflows/publish-libs.yml
+++ b/.github/workflows/publish-libs.yml
@@ -2,6 +2,7 @@ name: Publish PFM Common Libraries
 
 on:
   workflow_dispatch:
+  pull_request:
   workflow_run:
     workflows: [Create Git Release]
     types: [completed]

--- a/.github/workflows/publish-libs.yml
+++ b/.github/workflows/publish-libs.yml
@@ -2,7 +2,6 @@ name: Publish PFM Common Libraries
 
 on:
   workflow_dispatch:
-  pull_request:
   workflow_run:
     workflows: [Create Git Release]
     types: [completed]

--- a/PFM.Api/src/PFM.Api.Contracts/PFM.Api.Contracts.csproj
+++ b/PFM.Api/src/PFM.Api.Contracts/PFM.Api.Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>JM89</Authors>
     <PackageDescription>Contracts shared between the PFM API and Website.</PackageDescription>
   </PropertyGroup>

--- a/PFM.Website/PersonalFinanceManager/App_Start/NinjectConfig.cs
+++ b/PFM.Website/PersonalFinanceManager/App_Start/NinjectConfig.cs
@@ -2,6 +2,7 @@
 using PersonalFinanceManager.Services.Core;
 using Ninject.Extensions.Conventions;
 using Ninject.Web.Common;
+using Serilog;
 
 namespace PersonalFinanceManager.App_Start
 {
@@ -16,6 +17,12 @@ namespace PersonalFinanceManager.App_Start
 
         private void RegisterServices()
         {
+            Log.Logger = new LoggerConfiguration()
+              .ReadFrom.AppSettings()
+              .CreateLogger();
+
+            Kernel.Bind<ILogger>().ToConstant(Log.Logger);
+
             //Default interface in this scenario means that if your interface is named IXService, then the class named XService will be binded to it. 
             Kernel.Bind(x => x.FromAssemblyContaining(typeof(IBaseService))
                             .SelectAllClasses()

--- a/PFM.Website/PersonalFinanceManager/App_Start/Startup.Ninject.cs
+++ b/PFM.Website/PersonalFinanceManager/App_Start/Startup.Ninject.cs
@@ -3,6 +3,7 @@ using Ninject.Web.Common.OwinHost;
 using Owin;
 using PersonalFinanceManager.App_Start;
 using PersonalFinanceManager.Services.Core;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/PFM.Website/PersonalFinanceManager/Controllers/AccountManagementController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/AccountManagementController.cs
@@ -21,7 +21,7 @@ namespace PersonalFinanceManager.Controllers
         private readonly IPaymentMethodService _paymentMethodService;
 
         public AccountManagementController(IExpenditureService expenditureService, IBankAccountService bankAccountService, IBudgetPlanService budgetPlanService, IExpenditureTypeService expenditureTypeService, 
-            IPaymentMethodService paymentMethodService, IIncomeService incomeService, IAtmWithdrawService atmWithdrawService) : base(bankAccountService)
+            IPaymentMethodService paymentMethodService, IIncomeService incomeService, IAtmWithdrawService atmWithdrawService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._budgetPlanService = budgetPlanService;
             this._expenditureService = expenditureService;

--- a/PFM.Website/PersonalFinanceManager/Controllers/AtmWithdrawController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/AtmWithdrawController.cs
@@ -12,7 +12,7 @@ namespace PersonalFinanceManager.Controllers
     {
         private readonly IAtmWithdrawService _atmWithdrawService;
 
-        public AtmWithdrawController(IAtmWithdrawService atmWithdrawService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public AtmWithdrawController(IAtmWithdrawService atmWithdrawService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._atmWithdrawService = atmWithdrawService;
         }

--- a/PFM.Website/PersonalFinanceManager/Controllers/BankAccountController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/BankAccountController.cs
@@ -15,7 +15,7 @@ namespace PersonalFinanceManager.Controllers
         private readonly ICurrencyService _currencyService;
         private readonly IBankService _bankService;
 
-        public BankAccountController(IBankAccountService bankAccountService, ICurrencyService currencyService, IBankService bankService): base(bankAccountService)
+        public BankAccountController(IBankAccountService bankAccountService, ICurrencyService currencyService, IBankService bankService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._bankAccountService = bankAccountService;
             this._currencyService = currencyService;

--- a/PFM.Website/PersonalFinanceManager/Controllers/BankController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/BankController.cs
@@ -14,7 +14,7 @@ namespace PersonalFinanceManager.Controllers
         private readonly IBankService _bankService;
         private readonly ICountryService _countryService;
 
-        public BankController(IBankService bankService, ICountryService countryService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public BankController(IBankService bankService, ICountryService countryService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._bankService = bankService;
             this._countryService = countryService;

--- a/PFM.Website/PersonalFinanceManager/Controllers/BaseController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/BaseController.cs
@@ -9,7 +9,7 @@ namespace PersonalFinanceManager.Controllers
 {
     public class BaseController : Controller
     {
-        protected readonly Serilog.ILogger _log;
+        private readonly Serilog.ILogger _log;
 
         private readonly IBankAccountService _bankAccountService;
 

--- a/PFM.Website/PersonalFinanceManager/Controllers/BaseController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/BaseController.cs
@@ -1,22 +1,22 @@
-﻿using log4net;
-using Microsoft.AspNet.Identity;
+﻿using Microsoft.AspNet.Identity;
+using PersonalFinanceManager.Services.Exceptions;
 using PersonalFinanceManager.Services.Interfaces;
 using System;
 using System.Linq;
 using System.Web.Mvc;
-using PersonalFinanceManager.Services.Exceptions;
 
 namespace PersonalFinanceManager.Controllers
 {
     public class BaseController : Controller
     {
-        private readonly ILog _log = LogManager.GetLogger(typeof(BaseController));
+        protected readonly Serilog.ILogger _log;
 
         private readonly IBankAccountService _bankAccountService;
 
-        public BaseController(IBankAccountService bankAccountService)
+        public BaseController(IBankAccountService bankAccountService, Serilog.ILogger logger)
         {
             this._bankAccountService = bankAccountService;
+            this._log = logger;
         }
 
         protected override void OnException(ExceptionContext filterContext)

--- a/PFM.Website/PersonalFinanceManager/Controllers/BudgetPlanController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/BudgetPlanController.cs
@@ -18,7 +18,7 @@ namespace PersonalFinanceManager.Controllers
     {
         private readonly IBudgetPlanService _budgetPlanService;
 
-        public BudgetPlanController(IBudgetPlanService budgetPlanService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public BudgetPlanController(IBudgetPlanService budgetPlanService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._budgetPlanService = budgetPlanService;
         }

--- a/PFM.Website/PersonalFinanceManager/Controllers/CountryController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/CountryController.cs
@@ -10,7 +10,7 @@ namespace PersonalFinanceManager.Controllers
     {
         private readonly ICountryService _countryService;
 
-        public CountryController(ICountryService countryService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public CountryController(ICountryService countryService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._countryService = countryService;
         }

--- a/PFM.Website/PersonalFinanceManager/Controllers/CurrencyController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/CurrencyController.cs
@@ -10,7 +10,7 @@ namespace PersonalFinanceManager.Controllers
     {
         private readonly ICurrencyService _currencyService;
 
-        public CurrencyController(ICurrencyService currencyService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public CurrencyController(ICurrencyService currencyService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._currencyService = currencyService;
         }

--- a/PFM.Website/PersonalFinanceManager/Controllers/ExpenditureController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/ExpenditureController.cs
@@ -18,7 +18,7 @@ namespace PersonalFinanceManager.Controllers
         private readonly IBudgetPlanService _budgetPlanService;
 
         public ExpenditureController(IExpenditureService expenditureService, IExpenditureTypeService expenditureTypeService, IBankAccountService bankAccountService,
-            IPaymentMethodService paymentMethodService, IAtmWithdrawService atmWithdrawService, IBudgetPlanService budgetPlanService) : base(bankAccountService)
+            IPaymentMethodService paymentMethodService, IAtmWithdrawService atmWithdrawService, IBudgetPlanService budgetPlanService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._bankAccountService = bankAccountService;
             this._expenditureService = expenditureService;

--- a/PFM.Website/PersonalFinanceManager/Controllers/ExpenditureTypeController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/ExpenditureTypeController.cs
@@ -10,7 +10,7 @@ namespace PersonalFinanceManager.Controllers
     {
         private readonly IExpenditureTypeService _expenditureTypeService;
 
-        public ExpenditureTypeController(IExpenditureTypeService expenditureTypeService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public ExpenditureTypeController(IExpenditureTypeService expenditureTypeService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._expenditureTypeService = expenditureTypeService;
         }

--- a/PFM.Website/PersonalFinanceManager/Controllers/HomeController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/HomeController.cs
@@ -24,7 +24,7 @@ namespace PersonalFinanceManager.Controllers
         private readonly ICurrencyService _currencyService;
 
         public HomeController(IExpenditureService expenditureService, IPaymentMethodService paymentMethodService, IBankAccountService bankAccountService, 
-            IUserProfileService userProfileService, ICurrencyService currencyService): base(bankAccountService)
+            IUserProfileService userProfileService, ICurrencyService currencyService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._expenditureService = expenditureService;
             this._paymentMethodService = paymentMethodService;

--- a/PFM.Website/PersonalFinanceManager/Controllers/IncomeController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/IncomeController.cs
@@ -12,7 +12,7 @@ namespace PersonalFinanceManager.Controllers
     {
         private readonly IIncomeService _incomeService;
 
-        public IncomeController(IIncomeService incomeService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public IncomeController(IIncomeService incomeService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._incomeService = incomeService;
         }

--- a/PFM.Website/PersonalFinanceManager/Controllers/PaymentMethodController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/PaymentMethodController.cs
@@ -8,7 +8,7 @@ namespace PersonalFinanceManager.Controllers
     {
         private readonly IPaymentMethodService _paymentMethodService;
 
-        public PaymentMethodController(IPaymentMethodService paymentMethodService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public PaymentMethodController(IPaymentMethodService paymentMethodService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._paymentMethodService = paymentMethodService;
         }

--- a/PFM.Website/PersonalFinanceManager/Controllers/PensionController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/PensionController.cs
@@ -14,7 +14,7 @@ namespace PersonalFinanceManager.Controllers
         private readonly ICurrencyService _currencyService;
         private readonly ICountryService _countryService;
 
-        public PensionController(IPensionService pensionService, ICurrencyService currencyService, ICountryService countryService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public PensionController(IPensionService pensionService, ICurrencyService currencyService, ICountryService countryService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._pensionService = pensionService;
             this._currencyService = currencyService;

--- a/PFM.Website/PersonalFinanceManager/Controllers/SalaryController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/SalaryController.cs
@@ -17,7 +17,7 @@ namespace PersonalFinanceManager.Controllers
         private readonly ICountryService _countryService;
         private readonly ITaxService _taxService;
 
-        public SalaryController(ISalaryService salaryService, ICurrencyService currencyService, ICountryService countryService, ITaxService taxService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public SalaryController(ISalaryService salaryService, ICurrencyService currencyService, ICountryService countryService, ITaxService taxService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._salaryService = salaryService;
             this._currencyService = currencyService;

--- a/PFM.Website/PersonalFinanceManager/Controllers/SavingController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/SavingController.cs
@@ -14,7 +14,7 @@ namespace PersonalFinanceManager.Controllers
         private readonly ISavingService _savingService;
         private readonly IBankAccountService _bankAccountService;
 
-        public SavingController(ISavingService savingService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public SavingController(ISavingService savingService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._savingService = savingService;
             this._bankAccountService = bankAccountService;

--- a/PFM.Website/PersonalFinanceManager/Controllers/TaxController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/TaxController.cs
@@ -28,7 +28,7 @@ namespace PersonalFinanceManager.Controllers
         /// <param name="taxTypeService"></param>
         /// <param name="frequenceOptionService"></param>
         /// <param name="bankAccountService"></param>
-        public TaxController(ITaxService taxService, ICurrencyService currencyService, ICountryService countryService, ITaxTypeService taxTypeService, IFrequenceOptionService frequenceOptionService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public TaxController(ITaxService taxService, ICurrencyService currencyService, ICountryService countryService, ITaxTypeService taxTypeService, IFrequenceOptionService frequenceOptionService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._taxService = taxService;
             this._currencyService = currencyService;

--- a/PFM.Website/PersonalFinanceManager/Controllers/TaxTypeController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/TaxTypeController.cs
@@ -16,7 +16,7 @@ namespace PersonalFinanceManager.Controllers
         /// </summary>
         /// <param name="taxTypeService"></param>
         /// <param name="bankAccountService"></param>
-        public TaxTypeController(ITaxTypeService taxTypeService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public TaxTypeController(ITaxTypeService taxTypeService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._taxTypeService = taxTypeService;
         }

--- a/PFM.Website/PersonalFinanceManager/Controllers/UserProfileController.cs
+++ b/PFM.Website/PersonalFinanceManager/Controllers/UserProfileController.cs
@@ -18,7 +18,7 @@ namespace PersonalFinanceManager.Controllers
     {
         private readonly IUserProfileService _userProfileService;
 
-        public UserProfileController(IUserProfileService userProfileService, IBankAccountService bankAccountService) : base(bankAccountService)
+        public UserProfileController(IUserProfileService userProfileService, IBankAccountService bankAccountService, Serilog.ILogger logger) : base(bankAccountService, logger)
         {
             this._userProfileService = userProfileService;
         }

--- a/PFM.Website/PersonalFinanceManager/PersonalFinanceManager.csproj
+++ b/PFM.Website/PersonalFinanceManager/PersonalFinanceManager.csproj
@@ -49,10 +49,6 @@
       <HintPath>..\packages\AutoMapper.6.0.2\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Extensions.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
@@ -116,6 +112,9 @@
     </Reference>
     <Reference Include="Serilog.Formatting.Compact, Version=1.1.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Formatting.Compact.1.1.0\lib\net452\Serilog.Formatting.Compact.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Settings.AppSettings, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Settings.AppSettings.2.2.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Settings.Configuration, Version=3.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Settings.Configuration.3.4.0\lib\net461\Serilog.Settings.Configuration.dll</HintPath>

--- a/PFM.Website/PersonalFinanceManager/PersonalFinanceManager.csproj
+++ b/PFM.Website/PersonalFinanceManager/PersonalFinanceManager.csproj
@@ -54,6 +54,21 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.3.0.0\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
@@ -96,6 +111,30 @@
     <Reference Include="PFM.Authentication.Api.Contracts, Version=1.23.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PFM.Authentication.Api.Contracts.1.23.0\lib\netstandard2.0\PFM.Authentication.Api.Contracts.dll</HintPath>
     </Reference>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.12.0\lib\net47\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.1.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.1.0\lib\net452\Serilog.Formatting.Compact.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Settings.Configuration, Version=3.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Settings.Configuration.3.4.0\lib\net461\Serilog.Settings.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Console, Version=4.1.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Console.4.1.0\lib\net45\Serilog.Sinks.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=5.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.5.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=3.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.3.1.0\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Seq, Version=5.2.2.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Seq.5.2.2\lib\net45\Serilog.Sinks.Seq.dll</HintPath>
+    </Reference>
+    <Reference Include="SerilogTimings, Version=3.0.1.0, Culture=neutral, PublicKeyToken=ea6fc7d88906f03a, processorArchitecture=MSIL">
+      <HintPath>..\packages\SerilogTimings.3.0.1\lib\netstandard2.0\SerilogTimings.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
@@ -104,6 +143,14 @@
     <Reference Include="System.IO" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.4.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/PFM.Website/PersonalFinanceManager/PersonalFinanceManager.csproj
+++ b/PFM.Website/PersonalFinanceManager/PersonalFinanceManager.csproj
@@ -101,8 +101,8 @@
       <HintPath>..\packages\Ninject.Web.Common.OwinHost.3.2.3.0\lib\net45-full\Ninject.Web.Common.OwinHost.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="PFM.Api.Contracts, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PFM.Api.Contracts.1.0.0\lib\netstandard2.0\PFM.Api.Contracts.dll</HintPath>
+    <Reference Include="PFM.Api.Contracts, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PFM.Api.Contracts.2.0.1-PullRequest0073.2\lib\netstandard2.0\PFM.Api.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="PFM.Authentication.Api.Contracts, Version=1.23.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PFM.Authentication.Api.Contracts.1.23.0\lib\netstandard2.0\PFM.Authentication.Api.Contracts.dll</HintPath>

--- a/PFM.Website/PersonalFinanceManager/Services/AccountService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/AccountService.cs
@@ -7,10 +7,17 @@ namespace PersonalFinanceManager.Services
 {
     public class AccountService : IAccountService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public AccountService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public UserResponse Login(LoginViewModel user)
         {
             UserResponse result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.UserAccount.User>(user);
                 result = httpClient.Post<PFM.Api.Contracts.UserAccount.User, UserResponse>($"/Account/Login", dto, new HttpClientRequestOptions() {
@@ -23,7 +30,7 @@ namespace PersonalFinanceManager.Services
         public string Register(RegisterViewModel user)
         {
             string result = "";
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.UserAccount.User>(user);
                 result = httpClient.Post<PFM.Api.Contracts.UserAccount.User, string>($"/Account/Register", dto, new HttpClientRequestOptions()

--- a/PFM.Website/PersonalFinanceManager/Services/AccountService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/AccountService.cs
@@ -19,8 +19,8 @@ namespace PersonalFinanceManager.Services
             UserResponse result = null;
             using (var httpClient = new HttpClientExtended(_logger))
             {
-                var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.UserAccount.User>(user);
-                result = httpClient.Post<PFM.Api.Contracts.UserAccount.User, UserResponse>($"/Account/Login", dto, new HttpClientRequestOptions() {
+                var dto = new UserRequest() { Username = user.Email, Password = user.Password };
+                result = httpClient.Post<UserRequest, UserResponse>($"/Account/Login", dto, new HttpClientRequestOptions() {
                     AuthenticationTokenRequired = false
                 });
             }
@@ -29,16 +29,16 @@ namespace PersonalFinanceManager.Services
 
         public string Register(RegisterViewModel user)
         {
-            string result = "";
+            UserResponse result = null;
             using (var httpClient = new HttpClientExtended(_logger))
             {
-                var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.UserAccount.User>(user);
-                result = httpClient.Post<PFM.Api.Contracts.UserAccount.User, string>($"/Account/Register", dto, new HttpClientRequestOptions()
+                var dto = new UserRequest() { Username = user.Email, Password = user.Password, FirstName = "", LastName = "" };
+                result = httpClient.Post<UserRequest, UserResponse>($"/Account/Register", dto, new HttpClientRequestOptions()
                 {
                     AuthenticationTokenRequired = false
                 });
             }
-            return result;
+            return result.Token;
         }
     }
 }

--- a/PFM.Website/PersonalFinanceManager/Services/AtmWithdrawService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/AtmWithdrawService.cs
@@ -1,18 +1,24 @@
-﻿using System.Collections.Generic;
-using PersonalFinanceManager.Models.AtmWithdraw;
-using PersonalFinanceManager.Services.Interfaces;
-using System;
+﻿using PersonalFinanceManager.Models.AtmWithdraw;
 using PersonalFinanceManager.Services.HttpClientWrapper;
+using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class AtmWithdrawService : IAtmWithdrawService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public AtmWithdrawService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<AtmWithdrawListModel> GetAtmWithdrawsByAccountId(int accountId)
         {
             IList<AtmWithdrawListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.AtmWithdraw.AtmWithdrawList>($"/AtmWithdraw/GetList/{accountId}");
                 result = response.Select(AutoMapper.Mapper.Map<AtmWithdrawListModel>).ToList();
@@ -22,7 +28,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateAtmWithdraws(List<AtmWithdrawEditModel> models)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = models.Select(AutoMapper.Mapper.Map<PFM.Api.Contracts.AtmWithdraw.AtmWithdrawDetails>).ToList();
                 httpClient.Post($"/AtmWithdraw/CreateAtmWithdraws", dto);
@@ -31,7 +37,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateAtmWithdraw(AtmWithdrawEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.AtmWithdraw.AtmWithdrawDetails>(model);
                 httpClient.Post($"/AtmWithdraw/Create", dto);
@@ -41,7 +47,7 @@ namespace PersonalFinanceManager.Services
         public AtmWithdrawEditModel GetById(int id)
         {
             AtmWithdrawEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.AtmWithdraw.AtmWithdrawDetails>($"/AtmWithdraw/Get/{id}");
                 result = AutoMapper.Mapper.Map<AtmWithdrawEditModel>(response);
@@ -51,7 +57,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditAtmWithdraw(AtmWithdrawEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.AtmWithdraw.AtmWithdrawDetails>(model);
                 httpClient.Put($"/AtmWithdraw/Edit/{model.Id}", dto);
@@ -60,7 +66,7 @@ namespace PersonalFinanceManager.Services
         
         public void CloseAtmWithdraw(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Post($"/AtmWithdraw/CloseAtmWithdraw/{id}");
             }
@@ -68,7 +74,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteAtmWithdraw(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/AtmWithdraw/Delete/{id}");
             }
@@ -76,7 +82,7 @@ namespace PersonalFinanceManager.Services
 
         public void ChangeDebitStatus(int id, bool debitStatus)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/AtmWithdraw/ChangeDebitStatus/{id}/{debitStatus}");
             }

--- a/PFM.Website/PersonalFinanceManager/Services/Automapper/DTOToModelMapping.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/Automapper/DTOToModelMapping.cs
@@ -60,7 +60,6 @@ namespace PersonalFinanceManager.Services.Automapper
             CreateMap<PFM.Api.Contracts.Tax.TaxList, Models.Tax.TaxListModel>();
             CreateMap<PFM.Api.Contracts.TaxType.TaxTypeList, Models.TaxType.TaxTypeListModel>();
             CreateMap<PFM.Api.Contracts.UserProfile.UserProfileDetails, Models.UserProfile.UserProfileEditModel>();
-            CreateMap<PFM.Api.Contracts.UserAccount.AuthenticatedUser, Models.AspNetUserAccount.AuthenticatedUser>();
         }
     }
 }

--- a/PFM.Website/PersonalFinanceManager/Services/Automapper/ModelToDTOMapping.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/Automapper/ModelToDTOMapping.cs
@@ -31,8 +31,6 @@ namespace PersonalFinanceManager.Services.Automapper
             CreateMap<Models.Saving.SavingEditModel, PFM.Api.Contracts.Saving.SavingDetails>();
             CreateMap<Models.Tax.TaxEditModel, PFM.Api.Contracts.Tax.TaxDetails>();
             CreateMap<Models.UserProfile.UserProfileEditModel, PFM.Api.Contracts.UserProfile.UserProfileDetails>();
-            CreateMap<Models.AspNetUserAccount.LoginViewModel, PFM.Api.Contracts.UserAccount.User>();
-            CreateMap<Models.AspNetUserAccount.RegisterViewModel, PFM.Api.Contracts.UserAccount.User>();
         }
     }
 }

--- a/PFM.Website/PersonalFinanceManager/Services/BankAccountService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/BankAccountService.cs
@@ -9,9 +9,16 @@ namespace PersonalFinanceManager.Services
 {
     public class BankAccountService: IBankAccountService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public BankAccountService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public void CreateBankAccount(AccountEditModel model, string userId)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Account.AccountDetails>(model);
                 httpClient.Post($"/BankAccount/Create/{userId}", dto);
@@ -21,7 +28,7 @@ namespace PersonalFinanceManager.Services
         public IList<AccountListModel> GetAccountsByUser(string userId)
         {
             IList<AccountListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.Account.AccountList>($"/BankAccount/GetList/{userId}");
                 result = response.Select(AutoMapper.Mapper.Map<AccountListModel>).ToList();
@@ -32,7 +39,7 @@ namespace PersonalFinanceManager.Services
         public AccountEditModel GetById(int id)
         {
             AccountEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Account.AccountDetails>($"/BankAccount/Get/{id}");
                 result = AutoMapper.Mapper.Map<AccountEditModel>(response);
@@ -42,7 +49,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditBankAccount(AccountEditModel model, string userId)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Account.AccountDetails>(model);
                 httpClient.Put($"/BankAccount/Edit/{model.Id}/{userId}", dto);
@@ -51,7 +58,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteBankAccount(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/BankAccount/Delete/{id}");
             }
@@ -59,7 +66,7 @@ namespace PersonalFinanceManager.Services
         
         public void SetAsFavorite(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Post($"/BankAccount/SetAsFavorite/{id}");
             }

--- a/PFM.Website/PersonalFinanceManager/Services/BankService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/BankService.cs
@@ -1,18 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using PersonalFinanceManager.Models.Bank;
+﻿using PersonalFinanceManager.Models.Bank;
 using PersonalFinanceManager.Services.HttpClientWrapper;
 using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class BankService : IBankService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public BankService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<BankListModel> GetBanks()
         {
             IList<BankListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.Bank.BankList>($"/Bank/GetList");
                 result = response.Select(AutoMapper.Mapper.Map<BankListModel>).ToList();
@@ -22,7 +28,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateBank(BankEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Bank.BankDetails>(model);
                 httpClient.Post($"/Bank/Create", dto);
@@ -32,7 +38,7 @@ namespace PersonalFinanceManager.Services
         public BankEditModel GetById(int id)
         {
             BankEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Bank.BankDetails>($"/Bank/Get/{id}");
                 result = AutoMapper.Mapper.Map<BankEditModel>(response);
@@ -42,7 +48,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditBank(BankEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Bank.BankDetails>(model);
                 httpClient.Put($"/Bank/Edit/{model.Id}", dto);
@@ -51,7 +57,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteBank(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/Bank/Delete/{id}");
             }

--- a/PFM.Website/PersonalFinanceManager/Services/BudgetPlanService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/BudgetPlanService.cs
@@ -1,18 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using PersonalFinanceManager.Models.BudgetPlan;
+﻿using PersonalFinanceManager.Models.BudgetPlan;
 using PersonalFinanceManager.Services.HttpClientWrapper;
 using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class BudgetPlanService : IBudgetPlanService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public BudgetPlanService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<BudgetPlanListModel> GetBudgetPlans(int accountId)
         {
             IList<BudgetPlanListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.BudgetPlan.BudgetPlanList>($"/BudgetPlan/GetList/{accountId}");
                 result = response.Select(AutoMapper.Mapper.Map<BudgetPlanListModel>).ToList();
@@ -23,7 +29,7 @@ namespace PersonalFinanceManager.Services
         public BudgetPlanEditModel GetCurrent(int accountId)
         {
             BudgetPlanEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.BudgetPlan.BudgetPlanDetails>($"/BudgetPlan/GetCurrent/{accountId}");
                 result = AutoMapper.Mapper.Map<BudgetPlanEditModel>(response);
@@ -34,7 +40,7 @@ namespace PersonalFinanceManager.Services
         public BudgetPlanEditModel GetById(int id)
         {
             BudgetPlanEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.BudgetPlan.BudgetPlanDetails>($"/BudgetPlan/Get/{id}");
                 result = AutoMapper.Mapper.Map<BudgetPlanEditModel>(response);
@@ -44,7 +50,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateBudgetPlan(BudgetPlanEditModel model, int accountId)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.BudgetPlan.BudgetPlanDetails>(model);
                 httpClient.Post($"/BudgetPlan/Create/{accountId}", dto);
@@ -53,7 +59,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditBudgetPlan(BudgetPlanEditModel model, int accountId)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.BudgetPlan.BudgetPlanDetails>(model);
                 httpClient.Put($"/BudgetPlan/Edit/{accountId}", dto);
@@ -62,7 +68,7 @@ namespace PersonalFinanceManager.Services
 
         public void StartBudgetPlan(int value, int accountId)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Post($"/BudgetPlan/Start/{value}/{accountId}");
             }
@@ -70,7 +76,7 @@ namespace PersonalFinanceManager.Services
 
         public void StopBudgetPlan(int value)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Post($"/BudgetPlan/Stop/{value}");
             }
@@ -79,7 +85,7 @@ namespace PersonalFinanceManager.Services
         public BudgetPlanEditModel BuildBudgetPlan(int accountId, int? budgetPlanId = null)
         {
             BudgetPlanEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var url = budgetPlanId.HasValue ? $"/BudgetPlan/BuildEmpty/{accountId}/{budgetPlanId}" : $"/BudgetPlan/BuildEmpty/{accountId}";
                 var response = httpClient.GetSingle<PFM.Api.Contracts.BudgetPlan.BudgetPlanDetails>(url);

--- a/PFM.Website/PersonalFinanceManager/Services/CountryService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/CountryService.cs
@@ -1,18 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using PersonalFinanceManager.Models.Country;
+﻿using PersonalFinanceManager.Models.Country;
 using PersonalFinanceManager.Services.HttpClientWrapper;
 using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class CountryService : ICountryService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public CountryService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<CountryListModel> GetCountries()
         {
             IList<CountryListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.Country.CountryList>($"/Country/GetList");
                 result = response.Select(AutoMapper.Mapper.Map<CountryListModel>).ToList();
@@ -22,7 +28,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateCountry(CountryEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Country.CountryDetails>(model);
                 httpClient.Post($"/Country/Create", dto);
@@ -32,7 +38,7 @@ namespace PersonalFinanceManager.Services
         public CountryEditModel GetById(int id)
         {
             CountryEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Country.CountryDetails>($"/Country/Get/{id}");
                 result = AutoMapper.Mapper.Map<CountryEditModel>(response);
@@ -42,7 +48,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditCountry(CountryEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Country.CountryDetails>(model);
                 httpClient.Put($"/Country/Edit/{model.Id}", dto);
@@ -51,7 +57,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteCountry(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/Country/Delete/{id}");
             }

--- a/PFM.Website/PersonalFinanceManager/Services/CurrencyService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/CurrencyService.cs
@@ -1,18 +1,24 @@
-﻿using System.Collections.Generic;
-using PersonalFinanceManager.Models.Currency;
-using PersonalFinanceManager.Services.Interfaces;
-using System;
+﻿using PersonalFinanceManager.Models.Currency;
 using PersonalFinanceManager.Services.HttpClientWrapper;
+using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class CurrencyService : ICurrencyService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public CurrencyService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<CurrencyListModel> GetCurrencies()
         {
             IList<CurrencyListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.Currency.CurrencyList>($"/Currency/GetList");
                 result = response.Select(AutoMapper.Mapper.Map<CurrencyListModel>).ToList();
@@ -23,7 +29,7 @@ namespace PersonalFinanceManager.Services
         public CurrencyEditModel GetById(int id)
         {
             CurrencyEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Currency.CurrencyDetails>($"/Currency/Get/{id}");
                 result = AutoMapper.Mapper.Map<CurrencyEditModel>(response);
@@ -33,7 +39,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateCurrency(CurrencyEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Currency.CurrencyDetails>(model);
                 httpClient.Post($"/Currency/Create", dto);
@@ -42,7 +48,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditCurrency(CurrencyEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Currency.CurrencyDetails>(model);
                 httpClient.Put($"/Currency/Edit/{model.Id}", dto);
@@ -51,7 +57,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteCurrency(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/Currency/Delete/{id}");
             }

--- a/PFM.Website/PersonalFinanceManager/Services/ExpenditureService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/ExpenditureService.cs
@@ -1,19 +1,25 @@
-﻿using System.Collections.Generic;
-using PersonalFinanceManager.Models.Expenditure;
-using PersonalFinanceManager.Services.Interfaces;
-using System;
+﻿using PersonalFinanceManager.Models.BudgetPlan;
 using PersonalFinanceManager.Models.Dashboard;
-using PersonalFinanceManager.Models.BudgetPlan;
-using System.Linq;
+using PersonalFinanceManager.Models.Expenditure;
 using PersonalFinanceManager.Services.HttpClientWrapper;
+using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class ExpenditureService : IExpenditureService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public ExpenditureService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public void CreateExpenditures(List<ExpenditureEditModel> models)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = models.Select(AutoMapper.Mapper.Map<PFM.Api.Contracts.Expense.ExpenseDetails>).ToList();
                 httpClient.Post($"/Expense/CreateExpenses", dto);
@@ -22,7 +28,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateExpenditure(ExpenditureEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Expense.ExpenseDetails>(model);
                 httpClient.Post($"/Expense/Create", dto);
@@ -31,7 +37,7 @@ namespace PersonalFinanceManager.Services
         
         public void EditExpenditure(ExpenditureEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Expense.ExpenseDetails>(model);
                 httpClient.Put($"/Expense/Edit/{model.Id}", dto);
@@ -40,7 +46,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteExpenditure(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/Expense/Delete/{id}");
             }
@@ -49,7 +55,7 @@ namespace PersonalFinanceManager.Services
         public ExpenditureEditModel GetById(int id)
         {
             ExpenditureEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Expense.ExpenseDetails>($"/Expense/Get/{id}");
                 result = AutoMapper.Mapper.Map<ExpenditureEditModel>(response);
@@ -59,7 +65,7 @@ namespace PersonalFinanceManager.Services
 
         public void ChangeDebitStatus(int id, bool debitStatus)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Post($"/Expense/ChangeDebitStatus/{id}/{debitStatus}");
             }
@@ -68,7 +74,7 @@ namespace PersonalFinanceManager.Services
         public IList<ExpenditureListModel> GetExpenditures(Models.SearchParameters.ExpenditureGetListSearchParameters search)
         {
             IList<ExpenditureListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var searchParameters = AutoMapper.Mapper.Map<PFM.Api.Contracts.SearchParameters.ExpenseGetListSearchParameters>(search);
                 var response = httpClient.GetListBySearchParameters<PFM.Api.Contracts.Expense.ExpenseList, PFM.Api.Contracts.SearchParameters.ExpenseGetListSearchParameters>("/Expense/GetExpenses", searchParameters);
@@ -80,7 +86,7 @@ namespace PersonalFinanceManager.Services
         public ExpenseSummaryModel GetExpenseSummary(int accountId, BudgetPlanEditModel model)
         {
             ExpenseSummaryModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.BudgetPlan.BudgetPlanDetails>(model);
                 var response = httpClient.Post<PFM.Api.Contracts.BudgetPlan.BudgetPlanDetails, PFM.Api.Contracts.Dashboard.ExpenseSummary>($"/Expense/GetExpenseSummary/{accountId}", dto);

--- a/PFM.Website/PersonalFinanceManager/Services/ExpenditureTypeService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/ExpenditureTypeService.cs
@@ -1,18 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using PersonalFinanceManager.Models.ExpenditureType;
+﻿using PersonalFinanceManager.Models.ExpenditureType;
 using PersonalFinanceManager.Services.HttpClientWrapper;
 using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class ExpenditureTypeService : IExpenditureTypeService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public ExpenditureTypeService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<ExpenditureTypeListModel> GetExpenditureTypes()
         {
             IList<ExpenditureTypeListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.ExpenseType.ExpenseTypeList>($"/ExpenseType/GetList");
                 result = response.Select(AutoMapper.Mapper.Map<ExpenditureTypeListModel>).ToList();
@@ -23,7 +29,7 @@ namespace PersonalFinanceManager.Services
         public ExpenditureTypeEditModel GetById(int id)
         {
             ExpenditureTypeEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.ExpenseType.ExpenseTypeDetails>($"/ExpenseType/Get/{id}");
                 result = AutoMapper.Mapper.Map<ExpenditureTypeEditModel>(response);
@@ -33,7 +39,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateExpenditureType(ExpenditureTypeEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.ExpenseType.ExpenseTypeDetails>(model);
                 httpClient.Post($"/ExpenseType/Create", dto);
@@ -42,7 +48,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditExpenditureType(ExpenditureTypeEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.ExpenseType.ExpenseTypeDetails>(model);
                 httpClient.Put($"/ExpenseType/Edit/{model.Id}", dto);
@@ -51,7 +57,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteExpenditureType(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/ExpenseType/Delete/{id}");
             }

--- a/PFM.Website/PersonalFinanceManager/Services/FrequenceOptionService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/FrequenceOptionService.cs
@@ -1,18 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using PersonalFinanceManager.Services.Interfaces;
-using PersonalFinanceManager.Models.FrequenceOption;
+﻿using PersonalFinanceManager.Models.FrequenceOption;
 using PersonalFinanceManager.Services.HttpClientWrapper;
+using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class FrequenceOptionService : IFrequenceOptionService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public FrequenceOptionService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<FrequenceOptionListModel> GetFrequencyOptions()
         {
             IList<FrequenceOptionListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.FrequenceOption.FrequenceOptionList>($"/FrequenceOption/GetList");
                 result = response.Select(AutoMapper.Mapper.Map<FrequenceOptionListModel>).ToList();

--- a/PFM.Website/PersonalFinanceManager/Services/HttpClientWrapper/HttpClientExtended.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/HttpClientWrapper/HttpClientExtended.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
-using System.Threading;
 using System.Web;
 
 namespace PersonalFinanceManager.Services.HttpClientWrapper
@@ -15,10 +14,12 @@ namespace PersonalFinanceManager.Services.HttpClientWrapper
     public class HttpClientExtended : HttpClient
     {
         private readonly string _apiBaseUrl;
+        private readonly Serilog.ILogger _logger;
 
-        public HttpClientExtended()
+        public HttpClientExtended(Serilog.ILogger logger)
         {
             _apiBaseUrl = ConfigurationManager.AppSettings["PfmApiUrl"];
+            _logger = logger;
         }
 
         public IList<TResult> GetList<TResult>(string url, HttpClientRequestOptions opts = null)
@@ -29,27 +30,36 @@ namespace PersonalFinanceManager.Services.HttpClientWrapper
             }
 
             IList<TResult> result = null;
-            using (var httpClient = new HttpClient())
-            {
-                if (opts.AuthenticationTokenRequired)
-                {
-                    httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
-                }
 
-                var endpoint = _apiBaseUrl+ url;
-                var call = httpClient.GetAsync(endpoint);
-                call.Wait();
-                var httpResponse = call.Result;
-                if (httpResponse.IsSuccessStatusCode)
+            try
+            {
+                using (var httpClient = new HttpClient())
                 {
-                    var content = httpResponse.Content.ReadAsStringAsync();
-                    content.Wait();
-                    result = JsonConvert.DeserializeObject<IList<TResult>>(content.Result).ToList();
+                    if (opts.AuthenticationTokenRequired)
+                    {
+                        httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
+                    }
+
+                    var endpoint = _apiBaseUrl + url;
+                    var call = httpClient.GetAsync(endpoint);
+                    call.Wait();
+                    var httpResponse = call.Result;
+                    if (httpResponse.IsSuccessStatusCode)
+                    {
+                        var content = httpResponse.Content.ReadAsStringAsync();
+                        content.Wait();
+                        result = JsonConvert.DeserializeObject<IList<TResult>>(content.Result).ToList();
+                    }
+                    else
+                    {
+                        throw new ApiException(url, httpResponse.StatusCode.ToString());
+                    }
                 }
-                else
-                {
-                    throw new ApiException(url, httpResponse.StatusCode.ToString());
-                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unhandled exception occurred while calling GetList method");
+                throw;
             }
             return result;
         }
@@ -61,27 +71,36 @@ namespace PersonalFinanceManager.Services.HttpClientWrapper
                 opts = new HttpClientRequestOptions();
             }
             TResult result = default(TResult);
-            using (var httpClient = new HttpClient())
+           
+            try
             {
-                if (opts.AuthenticationTokenRequired)
+                using (var httpClient = new HttpClient())
                 {
-                    httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
-                }
+                    if (opts.AuthenticationTokenRequired)
+                    {
+                        httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
+                    }
 
-                var endpoint = _apiBaseUrl + url;
-                var call = httpClient.GetAsync(endpoint);
-                call.Wait();
-                var httpResponse = call.Result;
-                if (httpResponse.IsSuccessStatusCode)
-                {
-                    var content = httpResponse.Content.ReadAsStringAsync();
-                    content.Wait();
-                    result = JsonConvert.DeserializeObject<TResult>(content.Result);
+                    var endpoint = _apiBaseUrl + url;
+                    var call = httpClient.GetAsync(endpoint);
+                    call.Wait();
+                    var httpResponse = call.Result;
+                    if (httpResponse.IsSuccessStatusCode)
+                    {
+                        var content = httpResponse.Content.ReadAsStringAsync();
+                        content.Wait();
+                        result = JsonConvert.DeserializeObject<TResult>(content.Result);
+                    }
+                    else
+                    {
+                        throw new ApiException(url, httpResponse.StatusCode.ToString());
+                    }
                 }
-                else
-                {
-                    throw new ApiException(url, httpResponse.StatusCode.ToString());
-                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unhandled exception occurred while calling GetSingle method");
+                throw;
             }
             return result;
         }
@@ -93,28 +112,37 @@ namespace PersonalFinanceManager.Services.HttpClientWrapper
                 opts = new HttpClientRequestOptions();
             }
             IList<TResult> result = null;
-            using (var httpClient = new HttpClient())
+
+            try 
+            { 
+                using (var httpClient = new HttpClient())
+                {
+                    if (opts.AuthenticationTokenRequired)
+                    {
+                        httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
+                    }
+                    var endpoint = _apiBaseUrl + url;
+                    var json = JsonConvert.SerializeObject(searchParameters);
+                    var requestBody = new StringContent(json, Encoding.UTF8, "application/json");
+                    var call = httpClient.PostAsync(endpoint, requestBody);
+                    call.Wait();
+                    var httpResponse = call.Result;
+                    if (httpResponse.IsSuccessStatusCode)
+                    {
+                        var content = httpResponse.Content.ReadAsStringAsync();
+                        content.Wait();
+                        result = JsonConvert.DeserializeObject<IList<TResult>>(content.Result).ToList();
+                    }
+                    else
+                    {
+                        throw new ApiException(url, httpResponse.StatusCode.ToString());
+                    }
+                }
+            }
+            catch (Exception ex)
             {
-                if (opts.AuthenticationTokenRequired)
-                {
-                    httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
-                }
-                var endpoint = _apiBaseUrl + url;
-                var json = JsonConvert.SerializeObject(searchParameters);
-                var requestBody = new StringContent(json, Encoding.UTF8, "application/json");
-                var call = httpClient.PostAsync(endpoint, requestBody);
-                call.Wait();
-                var httpResponse = call.Result;
-                if (httpResponse.IsSuccessStatusCode)
-                {
-                    var content = httpResponse.Content.ReadAsStringAsync();
-                    content.Wait();
-                    result = JsonConvert.DeserializeObject<IList<TResult>>(content.Result).ToList();
-                }
-                else
-                {
-                    throw new ApiException(url, httpResponse.StatusCode.ToString());
-                }
+                _logger.Error(ex, "Unhandled exception occurred while calling GetListBySearchParameters method");
+                throw;
             }
             return result;
         }
@@ -131,29 +159,40 @@ namespace PersonalFinanceManager.Services.HttpClientWrapper
                 opts = new HttpClientRequestOptions();
             }
             TResult result = default(TResult);
-            using (var httpClient = new HttpClient())
+
+            try
             {
-                if (opts.AuthenticationTokenRequired)
+                using (var httpClient = new HttpClient())
                 {
-                    httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
-                }
-                var endpoint = _apiBaseUrl + url;
-                var json = JsonConvert.SerializeObject(obj);
-                var requestBody = new StringContent(json, Encoding.UTF8, "application/json");
-                var call = httpClient.PostAsync(endpoint, requestBody);
-                call.Wait();
-                var httpResponse = call.Result;
-                if (httpResponse.IsSuccessStatusCode)
-                {
-                    var content = httpResponse.Content.ReadAsStringAsync();
-                    content.Wait();
-                    result = JsonConvert.DeserializeObject<TResult>(content.Result);
-                }
-                else
-                {
-                    throw new ApiException(url, httpResponse.StatusCode.ToString());
+                    if (opts.AuthenticationTokenRequired)
+                    {
+                        httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
+                    }
+
+                    var endpoint = _apiBaseUrl + url;
+                    var json = JsonConvert.SerializeObject(obj);
+                    var requestBody = new StringContent(json, Encoding.UTF8, "application/json");
+                    var call = httpClient.PostAsync(endpoint, requestBody);
+                    call.Wait();
+                    var httpResponse = call.Result;
+                    if (httpResponse.IsSuccessStatusCode)
+                    {
+                        var content = httpResponse.Content.ReadAsStringAsync();
+                        content.Wait();
+                        result = JsonConvert.DeserializeObject<TResult>(content.Result);
+                    }
+                    else
+                    {
+                        throw new ApiException(url, httpResponse.StatusCode.ToString());
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unhandled exception occurred while calling Post method");
+                throw;
+            }
+
             return result;
         }
 
@@ -163,26 +202,35 @@ namespace PersonalFinanceManager.Services.HttpClientWrapper
             {
                 opts = new HttpClientRequestOptions();
             }
-            using (var httpClient = new HttpClient())
-            {
-                if (opts.AuthenticationTokenRequired)
-                {
-                    httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
-                }
-                var endpoint = _apiBaseUrl + url;
 
-                var call = httpClient.PostAsync(endpoint, null);
-                call.Wait();
-                var httpResponse = call.Result;
-                if (httpResponse.IsSuccessStatusCode)
+            try
+            {
+                using (var httpClient = new HttpClient())
                 {
-                    var content = httpResponse.Content.ReadAsStringAsync();
-                    content.Wait();
+                    if (opts.AuthenticationTokenRequired)
+                    {
+                        httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
+                    }
+                    var endpoint = _apiBaseUrl + url;
+
+                    var call = httpClient.PostAsync(endpoint, null);
+                    call.Wait();
+                    var httpResponse = call.Result;
+                    if (httpResponse.IsSuccessStatusCode)
+                    {
+                        var content = httpResponse.Content.ReadAsStringAsync();
+                        content.Wait();
+                    }
+                    else
+                    {
+                        throw new ApiException(url, httpResponse.StatusCode.ToString());
+                    }
                 }
-                else
-                {
-                    throw new ApiException(url, httpResponse.StatusCode.ToString());
-                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unhandled exception occurred while calling Post method");
+                throw;
             }
         }
 
@@ -192,28 +240,37 @@ namespace PersonalFinanceManager.Services.HttpClientWrapper
             {
                 opts = new HttpClientRequestOptions();
             }
-            using (var httpClient = new HttpClient())
-            {
-                if (opts.AuthenticationTokenRequired)
-                {
-                    httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
-                }
-                var endpoint = _apiBaseUrl + url;
 
-                var json = JsonConvert.SerializeObject(obj);
-                var requestBody = new StringContent(json, Encoding.UTF8, "application/json");
-                var call = httpClient.PutAsync(endpoint, requestBody);
-                call.Wait();
-                var httpResponse = call.Result;
-                if (httpResponse.IsSuccessStatusCode)
+            try
+            { 
+                using (var httpClient = new HttpClient())
                 {
-                    var content = httpResponse.Content.ReadAsStringAsync();
-                    content.Wait();
+                    if (opts.AuthenticationTokenRequired)
+                    {
+                        httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
+                    }
+                    var endpoint = _apiBaseUrl + url;
+
+                    var json = JsonConvert.SerializeObject(obj);
+                    var requestBody = new StringContent(json, Encoding.UTF8, "application/json");
+                    var call = httpClient.PutAsync(endpoint, requestBody);
+                    call.Wait();
+                    var httpResponse = call.Result;
+                    if (httpResponse.IsSuccessStatusCode)
+                    {
+                        var content = httpResponse.Content.ReadAsStringAsync();
+                        content.Wait();
+                    }
+                    else
+                    {
+                        throw new ApiException(url, httpResponse.StatusCode.ToString());
+                    }
                 }
-                else
-                {
-                    throw new ApiException(url, httpResponse.StatusCode.ToString());
-                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unhandled exception occurred while calling Put method");
+                throw;
             }
         }
 
@@ -223,25 +280,34 @@ namespace PersonalFinanceManager.Services.HttpClientWrapper
             {
                 opts = new HttpClientRequestOptions();
             }
-            using (var httpClient = new HttpClient())
+
+            try
             {
-                if (opts.AuthenticationTokenRequired)
+                using (var httpClient = new HttpClient())
                 {
-                    httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
+                    if (opts.AuthenticationTokenRequired)
+                    {
+                        httpClient.DefaultRequestHeaders.Add("Authorization", GetAccessToken());
+                    }
+                    var endpoint = _apiBaseUrl + url;
+                    var call = httpClient.DeleteAsync(endpoint);
+                    call.Wait();
+                    var httpResponse = call.Result;
+                    if (httpResponse.IsSuccessStatusCode)
+                    {
+                        var content = httpResponse.Content.ReadAsStringAsync();
+                        content.Wait();
+                    }
+                    else
+                    {
+                        throw new ApiException(url, httpResponse.StatusCode.ToString());
+                    }
                 }
-                var endpoint = _apiBaseUrl + url;
-                var call = httpClient.DeleteAsync(endpoint);
-                call.Wait();
-                var httpResponse = call.Result;
-                if (httpResponse.IsSuccessStatusCode)
-                {
-                    var content = httpResponse.Content.ReadAsStringAsync();
-                    content.Wait();
-                }
-                else
-                {
-                    throw new ApiException(url, httpResponse.StatusCode.ToString());
-                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unhandled exception occurred while calling Delete method");
+                throw;
             }
         }
 

--- a/PFM.Website/PersonalFinanceManager/Services/IncomeService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/IncomeService.cs
@@ -1,17 +1,23 @@
-﻿using System.Collections.Generic;
-using PersonalFinanceManager.Models.Income;
-using PersonalFinanceManager.Services.Interfaces;
-using System;
+﻿using PersonalFinanceManager.Models.Income;
 using PersonalFinanceManager.Services.HttpClientWrapper;
+using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class IncomeService: IIncomeService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public IncomeService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public void CreateIncomes(List<IncomeEditModel> models)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = models.Select(AutoMapper.Mapper.Map<PFM.Api.Contracts.Income.IncomeDetails>).ToList();
                 httpClient.Post($"/Income/CreateIncomes", dto);
@@ -20,7 +26,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateIncome(IncomeEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Income.IncomeDetails>(model);
                 httpClient.Post($"/Income/Create", dto);
@@ -30,7 +36,7 @@ namespace PersonalFinanceManager.Services
         public IList<IncomeListModel> GetIncomes(int accountId)
         {
             IList<IncomeListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.Income.IncomeList>($"/Income/GetList/{accountId}");
                 result = response.Select(AutoMapper.Mapper.Map<IncomeListModel>).ToList();
@@ -41,7 +47,7 @@ namespace PersonalFinanceManager.Services
         public IncomeEditModel GetById(int id)
         {
             IncomeEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Income.IncomeDetails>($"/Income/Get/{id}");
                 result = AutoMapper.Mapper.Map<IncomeEditModel>(response);
@@ -51,7 +57,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditIncome(IncomeEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Income.IncomeDetails>(model);
                 httpClient.Put($"/Income/Edit/{model.Id}", dto);
@@ -60,7 +66,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteIncome(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/Income/Delete/{id}");
             }

--- a/PFM.Website/PersonalFinanceManager/Services/PaymentMethodService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/PaymentMethodService.cs
@@ -1,18 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using PersonalFinanceManager.Models.PaymentMethod;
+﻿using PersonalFinanceManager.Models.PaymentMethod;
 using PersonalFinanceManager.Services.HttpClientWrapper;
 using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class PaymentMethodService : IPaymentMethodService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public PaymentMethodService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<PaymentMethodListModel> GetPaymentMethods()
         {
             IList<PaymentMethodListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.PaymentMethod.PaymentMethodList>($"/PaymentMethod/GetList");
                 result = response.Select(AutoMapper.Mapper.Map<PaymentMethodListModel>).ToList();

--- a/PFM.Website/PersonalFinanceManager/Services/PensionService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/PensionService.cs
@@ -1,18 +1,24 @@
-﻿using PersonalFinanceManager.Services.Interfaces;
-using PersonalFinanceManager.Models.Pension;
-using System.Collections.Generic;
-using System;
+﻿using PersonalFinanceManager.Models.Pension;
 using PersonalFinanceManager.Services.HttpClientWrapper;
+using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class PensionService : IPensionService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public PensionService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<PensionListModel> GetPensions(string userId)
         {
             IList<PensionListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.Pension.PensionList>($"/Pension/GetList/{userId}");
                 result = response.Select(AutoMapper.Mapper.Map<PensionListModel>).ToList();
@@ -22,7 +28,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreatePension(PensionEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Pension.PensionDetails>(model);
                 httpClient.Post($"/Pension/Create", dto);
@@ -32,7 +38,7 @@ namespace PersonalFinanceManager.Services
         public PensionEditModel GetById(int id)
         {
             PensionEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Pension.PensionDetails>($"/Pension/Get/{id}");
                 result = AutoMapper.Mapper.Map<PensionEditModel>(response);
@@ -42,7 +48,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditPension(PensionEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Pension.PensionDetails>(model);
                 httpClient.Put($"/Pension/Edit/{model.Id}", dto);
@@ -51,7 +57,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeletePension(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/Pension/Delete/{id}");
             }

--- a/PFM.Website/PersonalFinanceManager/Services/SalaryService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/SalaryService.cs
@@ -1,18 +1,24 @@
-﻿using System.Collections.Generic;
-using PersonalFinanceManager.Services.Interfaces;
-using PersonalFinanceManager.Models.Salary;
-using System;
+﻿using PersonalFinanceManager.Models.Salary;
 using PersonalFinanceManager.Services.HttpClientWrapper;
+using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class SalaryService : ISalaryService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public SalaryService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<SalaryListModel> GetSalaries(string userId)
         {
             IList<SalaryListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.Salary.SalaryList>($"/Salary/GetList/{userId}");
                 result = response.Select(AutoMapper.Mapper.Map<SalaryListModel>).ToList();
@@ -22,7 +28,7 @@ namespace PersonalFinanceManager.Services
 
         public void CreateSalary(SalaryEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Salary.SalaryDetails>(model);
                 httpClient.Post($"/Salary/Create", dto);
@@ -31,7 +37,7 @@ namespace PersonalFinanceManager.Services
 
         public void CopySalary(int sourceId)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Post($"/Salary/CopySalary/{sourceId}");
             }
@@ -40,7 +46,7 @@ namespace PersonalFinanceManager.Services
         public SalaryEditModel GetById(int id)
         {
             SalaryEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Salary.SalaryDetails>($"/Salary/Get/{id}");
                 result = AutoMapper.Mapper.Map<SalaryEditModel>(response);
@@ -50,7 +56,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditSalary(SalaryEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Salary.SalaryDetails>(model);
                 httpClient.Put($"/Salary/Edit/{model.Id}", dto);
@@ -59,7 +65,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteSalary(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/Salary/Delete/{id}");
             }

--- a/PFM.Website/PersonalFinanceManager/Services/SavingService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/SavingService.cs
@@ -9,9 +9,16 @@ namespace PersonalFinanceManager.Services
 {
     public class SavingService : ISavingService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public SavingService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public void CreateSaving(SavingEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Saving.SavingDetails>(model);
                 httpClient.Post($"/Saving/Create", dto);
@@ -20,7 +27,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteSaving(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/Saving/Delete/{id}");
             }
@@ -28,7 +35,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditSaving(SavingEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Saving.SavingDetails>(model);
                 httpClient.Put($"/Saving/Edit/{model.Id}", dto);
@@ -38,7 +45,7 @@ namespace PersonalFinanceManager.Services
         public SavingEditModel GetById(int id)
         {
             SavingEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Saving.SavingDetails>($"/Saving/Get/{id}");
                 result = AutoMapper.Mapper.Map<SavingEditModel>(response);
@@ -49,7 +56,7 @@ namespace PersonalFinanceManager.Services
         public IList<SavingListModel> GetSavingsByAccountId(int accountId)
         {
             IList<SavingListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.Saving.SavingList>($"/Saving/GetList/{accountId}");
                 result = response.Select(AutoMapper.Mapper.Map<SavingListModel>).ToList();

--- a/PFM.Website/PersonalFinanceManager/Services/TaxService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/TaxService.cs
@@ -9,9 +9,16 @@ namespace PersonalFinanceManager.Services
 {
     public class TaxService : ITaxService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public TaxService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public void CreateTax(TaxEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Tax.TaxDetails>(model);
                 httpClient.Post($"/Tax/Create", dto);
@@ -20,7 +27,7 @@ namespace PersonalFinanceManager.Services
 
         public void DeleteTax(int id)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 httpClient.Delete($"/Tax/Delete/{id}");
             }
@@ -28,7 +35,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditTax(TaxEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.Tax.TaxDetails>(model);
                 httpClient.Put($"/Tax/Edit/{model.Id}", dto);
@@ -38,7 +45,7 @@ namespace PersonalFinanceManager.Services
         public TaxEditModel GetById(int id)
         {
             TaxEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.Tax.TaxDetails>($"/Tax/Get/{id}");
                 result = AutoMapper.Mapper.Map<TaxEditModel>(response);
@@ -49,7 +56,7 @@ namespace PersonalFinanceManager.Services
         public IList<TaxListModel> GetTaxes(string userId)
         {
             IList<TaxListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.Tax.TaxList>($"/Tax/GetList/{userId}");
                 result = response.Select(AutoMapper.Mapper.Map<TaxListModel>).ToList();
@@ -60,7 +67,7 @@ namespace PersonalFinanceManager.Services
         public IList<TaxListModel> GetTaxesByType(string currentUser, TaxType incomeTax)
         {
             IList<TaxListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var taxTypeId = (int)TaxType.IncomeTax;
                 var response = httpClient.GetList<PFM.Api.Contracts.Tax.TaxList>($"/Tax/GetTaxesByType/{currentUser}/{taxTypeId}");

--- a/PFM.Website/PersonalFinanceManager/Services/TaxTypeService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/TaxTypeService.cs
@@ -1,18 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using PersonalFinanceManager.Models.TaxType;
+﻿using PersonalFinanceManager.Models.TaxType;
 using PersonalFinanceManager.Services.HttpClientWrapper;
 using PersonalFinanceManager.Services.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PersonalFinanceManager.Services
 {
     public class TaxTypeService : ITaxTypeService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public TaxTypeService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public IList<TaxTypeListModel> GetTaxTypes()
         {
             IList<TaxTypeListModel> result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetList<PFM.Api.Contracts.TaxType.TaxTypeList>($"/TaxType/GetList");
                 result = response.Select(AutoMapper.Mapper.Map<TaxTypeListModel>).ToList();

--- a/PFM.Website/PersonalFinanceManager/Services/UserProfileService.cs
+++ b/PFM.Website/PersonalFinanceManager/Services/UserProfileService.cs
@@ -7,9 +7,16 @@ namespace PersonalFinanceManager.Services
 {
     public class UserProfileService : IUserProfileService
     {
+        private readonly Serilog.ILogger _logger;
+
+        public UserProfileService(Serilog.ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public void CreateUserProfile(UserProfileEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.UserProfile.UserProfileDetails>(model);
                 httpClient.Post($"/UserProfile/Create", dto);
@@ -19,7 +26,7 @@ namespace PersonalFinanceManager.Services
         public UserProfileEditModel GetByUserId(string userId)
         {
             UserProfileEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.UserProfile.UserProfileDetails>($"/UserProfile/GetByUserId/{userId}");
                 result = AutoMapper.Mapper.Map<UserProfileEditModel>(response);
@@ -29,7 +36,7 @@ namespace PersonalFinanceManager.Services
 
         public void EditUserProfile(UserProfileEditModel model)
         {
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var dto = AutoMapper.Mapper.Map<PFM.Api.Contracts.UserProfile.UserProfileDetails>(model);
                 httpClient.Put($"/UserProfile/Edit/{model.Id}", dto);
@@ -39,7 +46,7 @@ namespace PersonalFinanceManager.Services
         public UserProfileEditModel GetById(int id)
         {
             UserProfileEditModel result = null;
-            using (var httpClient = new HttpClientExtended())
+            using (var httpClient = new HttpClientExtended(_logger))
             {
                 var response = httpClient.GetSingle<PFM.Api.Contracts.UserProfile.UserProfileDetails>($"/UserProfile/Get/{id}");
                 result = AutoMapper.Mapper.Map<UserProfileEditModel>(response);

--- a/PFM.Website/PersonalFinanceManager/Startup.cs
+++ b/PFM.Website/PersonalFinanceManager/Startup.cs
@@ -1,8 +1,8 @@
-﻿using log4net.Config;
-using Microsoft.Owin;
+﻿using Microsoft.Owin;
 using Microsoft.Owin.Security.Cookies;
 using Owin;
 using PersonalFinanceManager.App_Start;
+using Serilog;
 using System.Web.Mvc;
 
 [assembly: OwinStartupAttribute(typeof(PersonalFinanceManager.Startup))]
@@ -10,11 +10,11 @@ namespace PersonalFinanceManager
 {
     public partial class Startup
     {
-
-
         public void Configuration(IAppBuilder app)
         {
-            XmlConfigurator.Configure();
+            Log.Logger = new LoggerConfiguration()
+              .ReadFrom.AppSettings()
+              .CreateLogger();
 
             ConfigureNinject(app);
 

--- a/PFM.Website/PersonalFinanceManager/Startup.cs
+++ b/PFM.Website/PersonalFinanceManager/Startup.cs
@@ -11,11 +11,7 @@ namespace PersonalFinanceManager
     public partial class Startup
     {
         public void Configuration(IAppBuilder app)
-        {
-            Log.Logger = new LoggerConfiguration()
-              .ReadFrom.AppSettings()
-              .CreateLogger();
-
+        {      
             ConfigureNinject(app);
 
             app.UseCookieAuthentication(new CookieAuthenticationOptions()

--- a/PFM.Website/PersonalFinanceManager/Web.config
+++ b/PFM.Website/PersonalFinanceManager/Web.config
@@ -18,7 +18,7 @@
     <add key="serilog:enrich:with-property:Environment" value="Development" />
     <add key="serilog:using:Console" value="Serilog.Sinks.Console" />
     <add key="serilog:using:Seq" value="Serilog.Sinks.Seq" />
-    <add key="serilog:write-to:Seq.serverUrl" value="http://localhost:5341"/>
+    <add key="serilog:write-to:Seq.serverUrl" value="http://localhost:5341" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/PFM.Website/PersonalFinanceManager/Web.config
+++ b/PFM.Website/PersonalFinanceManager/Web.config
@@ -4,27 +4,6 @@
   http://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
-  <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
-  </configSections>
-  <log4net>
-    <appender name="GeneralLog" type="log4net.Appender.RollingFileAppender">
-      <file value="..\\log\\general.log" />
-      <appendToFile value="true" />
-      <rollingStyle value="Size" />
-      <maxSizeRollBackups value="10" />
-      <maximumFileSize value="10MB" />
-      <staticLogFileName value="true" />
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%-5p %d %5rms %-22.22c{1} %-18.18M - %m%n" />
-      </layout>
-      <lockingModel type="log4net.Appender.RollingFileAppender+MinimalLock" />
-    </appender>
-    <root>
-      <level value="ERROR" />
-      <appender-ref ref="GeneralLog" />
-    </root>
-  </log4net>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
@@ -34,6 +13,7 @@
     <add key="BankIconMaxSize" value="200000" />
     <add key="BankIconBasePath" value="/Resources/bank_icons" />
     <add key="PfmApiUrl" value="https://localhost:4431/api" />
+    <add key="serilog:enrich:with-property:Environment" value="Development" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/PFM.Website/PersonalFinanceManager/Web.config
+++ b/PFM.Website/PersonalFinanceManager/Web.config
@@ -13,7 +13,12 @@
     <add key="BankIconMaxSize" value="200000" />
     <add key="BankIconBasePath" value="/Resources/bank_icons" />
     <add key="PfmApiUrl" value="https://localhost:4431/api" />
+    <add key="serilog:minimum-level" value="Debug" />
+    <add key="serilog:enrich:with-property:Application" value="PFM.Website" />
     <add key="serilog:enrich:with-property:Environment" value="Development" />
+    <add key="serilog:using:Console" value="Serilog.Sinks.Console" />
+    <add key="serilog:using:Seq" value="Serilog.Sinks.Seq" />
+    <add key="serilog:write-to:Seq.serverUrl" value="http://localhost:5341"/>
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/PFM.Website/PersonalFinanceManager/packages.config
+++ b/PFM.Website/PersonalFinanceManager/packages.config
@@ -16,6 +16,11 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Configuration" version="2.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="2.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.DependencyModel" version="3.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Primitives" version="2.0.0" targetFramework="net48" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.Net.Compilers" version="2.1.0" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.Owin" version="3.1.0" targetFramework="net452" />
@@ -33,9 +38,19 @@
   <package id="PFM.Api.Contracts" version="1.0.0" targetFramework="net48" />
   <package id="PFM.Authentication.Api.Contracts" version="1.23.0" targetFramework="net48" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
+  <package id="Serilog" version="2.12.0" targetFramework="net48" />
+  <package id="Serilog.Formatting.Compact" version="1.1.0" targetFramework="net48" />
+  <package id="Serilog.Settings.Configuration" version="3.4.0" targetFramework="net48" />
+  <package id="Serilog.Sinks.Console" version="4.1.0" targetFramework="net48" />
+  <package id="Serilog.Sinks.File" version="5.0.0" targetFramework="net48" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="3.1.0" targetFramework="net48" />
+  <package id="Serilog.Sinks.Seq" version="5.2.2" targetFramework="net48" />
+  <package id="SerilogTimings" version="3.0.1" targetFramework="net48" />
   <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.4.0" targetFramework="net48" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net48" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />

--- a/PFM.Website/PersonalFinanceManager/packages.config
+++ b/PFM.Website/PersonalFinanceManager/packages.config
@@ -8,7 +8,6 @@
   <package id="jQuery" version="1.10.2" targetFramework="net452" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net452" />
   <package id="jquery-globalize" version="1.0.0" targetFramework="net452" />
-  <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.Owin" version="2.2.1" targetFramework="net452" />
@@ -40,6 +39,7 @@
   <package id="Respond" version="1.2.0" targetFramework="net452" />
   <package id="Serilog" version="2.12.0" targetFramework="net48" />
   <package id="Serilog.Formatting.Compact" version="1.1.0" targetFramework="net48" />
+  <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net48" />
   <package id="Serilog.Settings.Configuration" version="3.4.0" targetFramework="net48" />
   <package id="Serilog.Sinks.Console" version="4.1.0" targetFramework="net48" />
   <package id="Serilog.Sinks.File" version="5.0.0" targetFramework="net48" />

--- a/PFM.Website/PersonalFinanceManager/packages.config
+++ b/PFM.Website/PersonalFinanceManager/packages.config
@@ -34,7 +34,7 @@
   <package id="Ninject.Web.Common" version="3.2.3.0" targetFramework="net452" />
   <package id="Ninject.Web.Common.OwinHost" version="3.2.3.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
-  <package id="PFM.Api.Contracts" version="1.0.0" targetFramework="net48" />
+  <package id="PFM.Api.Contracts" version="2.0.1-PullRequest0073.2" targetFramework="net48" />
   <package id="PFM.Authentication.Api.Contracts" version="1.23.0" targetFramework="net48" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
   <package id="Serilog" version="2.12.0" targetFramework="net48" />


### PR DESCRIPTION
## Changelog

### Global
- N/A

### PFM API
- Fix compatibility issue on the PFM.Api.Contracts lib

### PFM Auth API
- N/A

### PFM Website
- Add support for SEQ and pass ILogger around.
- Remove support for log4net 
- Add logging when errors occurred during calls.
- Fix breaking contracts for PFM.Auth.Api

## Comments
- [Review Httpclient implementation in the website](https://github.com/JM89/personalfinancemanager/issues/74)